### PR TITLE
feature:OP-19353:added new Dockerfileubi8 for RHEL ubi8.7-minimal-changes

### DIFF
--- a/Dockerfile.ubi8-minimal
+++ b/Dockerfile.ubi8-minimal
@@ -1,0 +1,61 @@
+FROM alpine:3 AS build
+RUN apk add --update \
+    openjdk11 \
+    && rm -rf /var/cache/apk
+LABEL maintainer="sig-platform@spinnaker.io"
+ENV GRADLE_USER_HOME /workspace/.gradle
+ENV GRADLE_OPTS -Xmx4g
+WORKDIR /build
+COPY . /build
+RUN ./gradlew --no-daemon rosco-web:installDist -x test
+
+FROM quay.io/opsmxpublic/image-base-java-ubi8-minimal:latest AS package
+LABEL maintainer="info@opsmx.io"
+
+ENV KUSTOMIZE_VERSION=3.10.0
+ENV KUSTOMIZE4_VERSION=4.5.7
+ENV PACKER_VERSION=1.8.6
+#ENV TARGETARCH=amd64
+
+ARG TARGETARCH
+
+WORKDIR /packer
+
+ENV PATH "/packer:$PATH"
+RUN  microdnf install --setopt=tsflags=nodocs openssl wget git openssh-clients unzip tar && \
+  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  unzip packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  rm packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 && \
+  chmod +x get-helm-3 && \
+  ./get-helm-3 && \
+  rm get-helm-3 && \
+  mv /usr/local/bin/helm /usr/local/bin/helm3 && \
+  wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
+  chmod +x get && \
+  ./get --version v2.17.0 && \
+  rm get && \
+  mkdir kustomize && \
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz|\
+  tar xvz -C kustomize/ && \
+  mv ./kustomize/kustomize /usr/local/bin/kustomize && \
+  rm -rf ./kustomize && \
+  mkdir kustomize && \
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE4_VERSION}/kustomize_v${KUSTOMIZE4_VERSION}_linux_${TARGETARCH}.tar.gz|\
+  tar xvz -C kustomize/ && \
+  mv ./kustomize/kustomize /usr/local/bin/kustomize4 && \
+  rm -rf ./kustomize && \
+  groupadd -g 10111 spinnaker && \
+  useradd -g spinnaker -u 10111 spinnaker && \
+  mkdir -p /opt/rosco/plugins && chown -R spinnaker:spinnaker /opt/rosco/plugins
+
+COPY --from=build /build/rosco-web/build/install/rosco /opt/rosco
+COPY --from=build /build/rosco-web/config              /opt/rosco
+COPY --from=build /build/halconfig/packer              /opt/rosco/config/packer
+USER spinnaker
+CMD ["/opt/rosco/bin/rosco"]
+
+
+
+
+

--- a/Dockerfileubi8
+++ b/Dockerfileubi8
@@ -1,0 +1,50 @@
+FROM quay.io/opsmxpublic/ubi8-jdk-11:v1
+LABEL maintainer="info@opsmx.io"
+
+ENV KUSTOMIZE_VERSION=3.8.6
+ENV KUSTOMIZE4_VERSION=4.5.5
+ENV PACKER_VERSION=1.8.1
+ENV TARGETARCH=amd64
+
+#ARG TARGETARCH
+
+WORKDIR /packer
+
+ENV PATH "/packer:$PATH"
+RUN  microdnf install --setopt=tsflags=nodocs openssl wget git openssh-clients unzip tar && \
+  wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  unzip packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  rm packer_${PACKER_VERSION}_linux_${TARGETARCH}.zip && \
+  wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get-helm-3 && \
+  chmod +x get-helm-3 && \
+  ./get-helm-3 && \
+  rm get-helm-3 && \
+  mv /usr/local/bin/helm /usr/local/bin/helm3 && \
+  wget https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
+  chmod +x get && \
+  ./get --version v2.17.0 && \
+  rm get && \
+  mkdir kustomize && \
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_${TARGETARCH}.tar.gz|\
+  tar xvz -C kustomize/ && \
+  mv ./kustomize/kustomize /usr/local/bin/kustomize && \
+  rm -rf ./kustomize && \
+  mkdir kustomize && \
+  curl -s -L https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v${KUSTOMIZE4_VERSION}/kustomize_v${KUSTOMIZE4_VERSION}_linux_${TARGETARCH}.tar.gz|\
+  tar xvz -C kustomize/ && \
+  mv ./kustomize/kustomize /usr/local/bin/kustomize4 && \
+  rm -rf ./kustomize && \
+  groupadd -g 10111 spinnaker && \
+  useradd -g spinnaker -u 10111 spinnaker && \
+  mkdir -p /opt/rosco/plugins && chown -R spinnaker:spinnaker /opt/rosco/plugins
+
+COPY rosco-web/build/install/rosco /opt/rosco
+COPY rosco-web/config              /opt/rosco
+COPY halconfig/packer              /opt/rosco/config/packer
+USER spinnaker
+CMD ["/opt/rosco/bin/rosco"]
+
+
+
+
+


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-19353
Changes done :
1. Copied Dockerfile.slim to Dockerfileubi8
2. Changed the base image from alpine to redhat
--- javabase file is committed at : 
https://github.com/OpsMx/image-base-java/blob/main/Dockerfile

 --- image is built and uploaded at:
http://quay.io/opsmxpublic/ubi8-jdk-11:v1

4. Added command to microdnf install required packages
5. Added group with group-id and added user with user-id
6. Changed ownership to plugins to the above spinnaker:spinnaker 
7. Combined all RUN commands in single RUN command to avoid multiple layers 