### PR TITLE
bugfix for OP-20338 NoSuchBeanDefinitionException: No qualifying bean of type com.netflix.spectator.api.Registry available issue

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/config/RoscoConfiguration.groovy
@@ -16,8 +16,6 @@
 
 package com.netflix.spinnaker.rosco.config
 
-import com.netflix.spectator.api.DefaultRegistry
-import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.config.PluginsAutoConfiguration
 import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
 import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
@@ -44,10 +42,6 @@ import redis.clients.jedis.JedisPool
 @Import(PluginsAutoConfiguration.class)
 class RoscoConfiguration {
 
-  @Bean
-  Registry getRegistry() {
-    return new DefaultRegistry();
-  }
 
   @Bean
   String roscoInstanceId() {


### PR DESCRIPTION
Fixed as suggested in:
https://github.com/spring-projects/spring-boot/issues/33413

The 3.0 [release notes link to the dedicated migration guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Release-Notes#upgrading-from-spring-boot-27), which is where most of the information needed when migrating from 2.7 to 3.0 is located.
and
https://medium.com/spring-boot/auto-configure-your-common-module-in-the-spring-boot-way-32acd3976a70