### PR TITLE
fix for cyclic dependency when aws bakery enabled

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/aws/config/RoscoAWSConfiguration.groovy
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
 import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Lazy
 
 @Configuration
 @ConditionalOnProperty('aws.enabled')
@@ -40,8 +41,12 @@ class RoscoAWSConfiguration {
   @Autowired
   CloudProviderBakeHandlerRegistry cloudProviderBakeHandlerRegistry
 
-  @Autowired
   AWSBakeHandler awsBakeHandler
+
+  @Autowired
+  RoscoAWSConfiguration(@Lazy AWSBakeHandler awsBakeHandler) {
+    this.awsBakeHandler = awsBakeHandler
+  }
 
   @Bean
   @ConfigurationProperties('aws.bakery-defaults')


### PR DESCRIPTION
cyclic dependency resolve not support in springboot 2.6 onwards, we have to enable it by using property 
`spring: 
  main:
    allow-circular-references: true`
or handle in code