### PR TITLE
fix for circulardependency issue while bean creation

### DIFF
--- a/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/config/RoscoGoogleConfiguration.groovy
+++ b/rosco-core/src/main/groovy/com/netflix/spinnaker/rosco/providers/google/config/RoscoGoogleConfiguration.groovy
@@ -31,6 +31,7 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
 import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Lazy
 
 @Configuration
 @ConditionalOnProperty('google.enabled')
@@ -40,7 +41,7 @@ class RoscoGoogleConfiguration {
   @Autowired
   CloudProviderBakeHandlerRegistry cloudProviderBakeHandlerRegistry
 
-  @Autowired
+  @Lazy @Autowired
   GCEBakeHandler gceBakeHandler
 
   @Bean


### PR DESCRIPTION
Summary
Project Jira : [https://devopsmx.atlassian.net/browse/OP-20559](url)
Project Doc : NA

Issue : classes GCEBakeHandler and RoscoGoogleConfiguration have inter dependencies and hence causing bean circular dependency. On making GCEBakeHandler to Lazy initialise allowing for creation of RoscoGoogleConfiguration to be created.

How changes are verified
Rosco is up and running. 

Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

Rollback, Deployment Details
Can this change be rolled back automatically without any issue? Yes
Is this a backwards-compatible change in your opinion ? Yes
Pre deployment steps : NA
Post deployment steps : NA