### PR TITLE
Update rosco-manifests.gradle - cve fix get default version from kork

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-retrofit"
   implementation "io.spinnaker.kork:kork-security"
-  implementation "commons-io:commons-io:2.11.0"
+  implementation "commons-io:commons-io"
   implementation "org.apache.commons:commons-compress:1.21"
   implementation "org.yaml:snakeyaml"
 


### PR DESCRIPTION
https://devopsmx.atlassian.net/browse/OP-20594 
