### PR TITLE
Removing explicit dependency version

### DIFF
--- a/rosco-manifests/rosco-manifests.gradle
+++ b/rosco-manifests/rosco-manifests.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation "io.spinnaker.kork:kork-exceptions"
   implementation "io.spinnaker.kork:kork-retrofit"
   implementation "io.spinnaker.kork:kork-security"
-  implementation "commons-io:commons-io:2.11.0"
+  implementation "commons-io:commons-io"
   implementation "org.apache.commons:commons-compress:1.21"
   implementation "org.yaml:snakeyaml"
 


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-20594)
**Project Doc :** NA

**Issue :** Removing explicit dependency version
**Solution :** Because it is coming from kork (spinaker-dependnecies)

### How changes are verified
Changed changes in kork local and verified required versions are reflecting using DI
gradle build and gradle test - successful

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** Need to check whether kork PR is merged or not, as required dependencies needs to be reflected from nexus
**Post deployment steps :** QA need to cross verify whether functionality is breaking or not