### PR TITLE
Added CD to rosco using githubAction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,18 @@ subprojects {
             annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
             testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
             testAnnotationProcessor "org.projectlombok:lombok"
-            testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
             testImplementation "org.springframework.boot:spring-boot-starter-test"
         }
 
         test {
             testLogging {
                 exceptionFormat = 'full'
+                afterSuite { desc, result ->
+                    if (!desc.parent) {
+                        println "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                        println "Report file: ${reports.html.entryPoint}"
+                    }
+                }
             }
             useJUnitPlatform()
         }

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/executor/BakePollerSpec.groovy
@@ -224,4 +224,3 @@ class BakePollerSpec extends Specification implements TestDefaults {
   }
 
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/CloudProviderBakeHandlerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.providers
 
-
 import com.google.common.base.Strings
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.rosco.providers.util.TestDefaults
@@ -72,4 +71,3 @@ class CloudProviderBakeHandlerSpec extends Specification implements TestDefaults
   }
 
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/alicloud/AliCloudBakeHandlerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.providers.alicloud
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
@@ -527,4 +526,3 @@ class AliCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$alicloudBakeryDefaults.templateFile")
   }
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/azure/AzureBakeHandlerSpec.groovy
@@ -607,4 +607,3 @@ class AzureBakeHandlerSpec extends Specification implements TestDefaults{
 
   }
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerBakeHandlerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.providers.docker
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
@@ -412,4 +411,3 @@ class DockerBakeHandlerSpec extends Specification implements TestDefaults {
   }
 
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/docker/DockerImageNameFactorySpec.groovy
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.rosco.providers.docker
 
-
 import com.netflix.spinnaker.rosco.api.BakeRequest
 import com.netflix.spinnaker.rosco.providers.util.TestDefaults
 import spock.lang.Specification
@@ -69,4 +68,3 @@ class DockerImageNameFactorySpec extends Specification implements TestDefaults {
       packagesParameter == "kato redis-server"
   }
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/google/GCEBakeHandlerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.providers.google
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
@@ -1097,4 +1096,3 @@ class GCEBakeHandlerSpec extends Specification implements TestDefaults{
       bakeKey == "bake:gce:centos:kato|nflx-djangobase-enhanced_0.1-h12.170cdbd_all|mongodb:my-other-google-account"
   }
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/huaweicloud/HuaweiCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/huaweicloud/HuaweiCloudBakeHandlerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.providers.huaweicloud
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest
@@ -520,4 +519,3 @@ class HuaweiCloudBakeHandlerSpec extends Specification implements TestDefaults {
       1 * packerCommandFactoryMock.buildPackerCommand("", parameterMap, null, "$configDir/$huaweicloudBakeryDefaults.templateFile")
   }
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/oracle/OCIBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/oracle/OCIBakeHandlerSpec.groovy
@@ -9,7 +9,6 @@
 
 package com.netflix.spinnaker.rosco.providers.oracle
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeOptions
@@ -255,4 +254,3 @@ class OCIBakeHandlerSpec extends Specification implements TestDefaults {
   }
 
 }
-

--- a/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/tencentcloud/TencentCloudBakeHandlerSpec.groovy
+++ b/rosco-core/src/test/groovy/com/netflix/spinnaker/rosco/providers/tencentcloud/TencentCloudBakeHandlerSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.providers.tencentcloud
 
-
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.rosco.api.Bake
 import com.netflix.spinnaker.rosco.api.BakeRequest

--- a/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizationFileReaderSpec.groovy
+++ b/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizationFileReaderSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.rosco.manifests.kustomize
 
-
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.rosco.manifests.kustomize.mapping.Kustomization
 import com.netflix.spinnaker.rosco.services.ClouddriverService
@@ -75,4 +74,3 @@ class KustomizationFileReaderSpec extends Specification {
         ex != null
     }
 }
-

--- a/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtilsSpec.groovy
+++ b/rosco-manifests/src/test/groovy/com/netflix/spinnaker/rosco/manifests/kustomize/KustomizeTemplateUtilsSpec.groovy
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.rosco.manifests.kustomize
 
-
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import com.netflix.spinnaker.rosco.jobs.BakeRecipe
 import com.netflix.spinnaker.rosco.manifests.ArtifactDownloader
@@ -249,4 +248,3 @@ class KustomizeTemplateUtilsSpec extends Specification {
         BakeManifestRequest.TemplateRenderer.KUSTOMIZE4 | "kustomize4"
     }
 }
-

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImplTest.java
@@ -31,14 +31,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
 import retrofit.RetrofitError;
 import retrofit.client.Response;
 import retrofit.mime.TypedByteArray;
 
-@RunWith(JUnitPlatform.class)
 final class ArtifactDownloaderImplTest {
   private final ClouddriverService clouddriverService = mock(ClouddriverService.class);
   private static final Artifact testArtifact =

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/BakeManifestEnvironmentTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/BakeManifestEnvironmentTest.java
@@ -23,10 +23,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 final class BakeManifestEnvironmentTest {
   @Test
   void rejectsInvalidPaths() throws IOException {

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/cloudfoundry/CloudFoundryBakeManifestServiceTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/cloudfoundry/CloudFoundryBakeManifestServiceTest.java
@@ -31,10 +31,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Base64;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 public class CloudFoundryBakeManifestServiceTest {
 
   private ArtifactDownloader artifactDownloader = mock(ArtifactDownloader.class);

--- a/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
+++ b/rosco-manifests/src/test/java/com/netflix/spinnaker/rosco/manifests/helm/HelmTemplateUtilsTest.java
@@ -60,11 +60,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.springframework.http.HttpStatus;
 
-@RunWith(JUnitPlatform.class)
 final class HelmTemplateUtilsTest {
 
   private ArtifactDownloader artifactDownloader;

--- a/rosco-web/src/test/java/com/netflix/spinnaker/rosco/controllers/V2BakeryControllerTest.java
+++ b/rosco-web/src/test/java/com/netflix/spinnaker/rosco/controllers/V2BakeryControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http:www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## Summary
Adding CD to rosco using github action. Now dev quay img will be automatically changed to ns=cvetarget cluster in rosco.yml, upon successful pre steps.

### How changes are verified
Pushed these chnges on branch=aman and verified that latest created quay img is reflected on cvetarget - checked by viewing rosco.yml https://github.com/OpsMx/rosco-oes/actions/runs/5408633164/jobs/9827899693

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

### Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** NA