### PR TITLE
Upgraded HASHICORP_PACKER - CVE fix

### DIFF
--- a/docker/ubi8/Dockerfile
+++ b/docker/ubi8/Dockerfile
@@ -6,7 +6,7 @@ COPY halconfig/packer              /opt/rosco/config/packer
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.9.1
+ENV PACKER_VERSION=1.10.0
 
 WORKDIR /packer
 

--- a/docker/ubi8/Dockerfile-dev
+++ b/docker/ubi8/Dockerfile-dev
@@ -39,7 +39,7 @@ COPY jaeger/opentelemetry-javaagent.jar /opt/jaeger/opentelemetry-javaagent.jar
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.9.1
+ENV PACKER_VERSION=1.10.0
 
 WORKDIR /packer
 

--- a/docker/ubi8/Dockerfile-fips
+++ b/docker/ubi8/Dockerfile-fips
@@ -37,7 +37,7 @@ COPY halconfig/packer              /opt/rosco/config/packer
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.9.1
+ENV PACKER_VERSION=1.10.0
 
 WORKDIR /packer
 
@@ -84,7 +84,7 @@ ENV CUSTOMPLUGIN_RELEASEREPO=$CUSTOMPLUGIN_RELEASEREPO
 ARG CUSTOMPLUGIN_RELEASEVERSION
 ENV CUSTOMPLUGIN_RELEASEVERSION=$CUSTOMPLUGIN_RELEASEVERSION
 
-RUN wget -O Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip -c https://github.com/${CUSTOMPLUGIN_RELEASEORG}/${CUSTOMPLUGIN_RELEASEREPO}/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}.zip -P /opt/rosco/plugins 
+RUN wget -O Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip -c https://github.com/${CUSTOMPLUGIN_RELEASEORG}/${CUSTOMPLUGIN_RELEASEREPO}/releases/download/${CUSTOMPLUGIN_RELEASEVERSION}/armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}.zip -P /opt/rosco/plugins
 
 RUN mv Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHOT.zip /opt/rosco/plugins/
 


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21536)
**Project Doc :** NA

**Issue/Feature :** Vulnerabilities in go pckgs
**Solution :** Updating HASHICORP_PACKER to [latest](https://github.com/hashicorp/packer/releases) version

### How changes are verified
1. Build success, No new TCs failing
2. Created new dockerImg, deployed on ns=testframe, verified changes by running 3-4 pipelines, watched the logs and didnt find any errors.
3. DockerImg for ref : aman1603/rosco:3jan2
Scanned the dockerImg using trivy on local ubuntu system & found that mentioned CVEs are resolved/fixed.

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** @yugaa22  pls update github actions accordingly
**Post deployment steps :** QA need to test more rigorously.