### PR TITLE
Fixed CVE-2023-49569 - Updated hashicorp packer version

### DIFF
--- a/docker/ubi8/Dockerfile
+++ b/docker/ubi8/Dockerfile
@@ -6,7 +6,7 @@ COPY halconfig/packer              /opt/rosco/config/packer
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.10.0
+ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 

--- a/docker/ubi8/Dockerfile-dev
+++ b/docker/ubi8/Dockerfile-dev
@@ -39,7 +39,7 @@ COPY jaeger/opentelemetry-javaagent.jar /opt/jaeger/opentelemetry-javaagent.jar
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.10.0
+ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 

--- a/docker/ubi8/Dockerfile-fips
+++ b/docker/ubi8/Dockerfile-fips
@@ -37,7 +37,7 @@ COPY halconfig/packer              /opt/rosco/config/packer
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.10.0
+ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 


### PR DESCRIPTION
## Summary
**Project Jira :** [Ref](https://devopsmx.atlassian.net/browse/OP-21766)
**Project Doc :** NA

**Issue :** CVE-2023-49569
**Solution :** Updated hashicorp packer version

### How changes are verified
details in jira

## Documentation Updates
Do we need to update dashboards? No
Do we need to update SOP, new hire wiki or other documents? No

## Rollback, Deployment Details
Can this change be rolled back automatically without any issue?  Yes
Is this a backwards-compatible change in your opinion ?  Yes
**Pre deployment steps :** NA
**Post deployment steps :** QA need to do regression testing