### PR TITLE
Upgrade Packer version - Fixed CVE-2023-49569

### DIFF
--- a/docker/ubi8/Dockerfile
+++ b/docker/ubi8/Dockerfile
@@ -6,13 +6,14 @@ COPY halconfig/packer              /opt/rosco/config/packer
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.9.1
+ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 
 RUN yum install -y java-17-openjdk-devel wget unzip curl tar git  openssl curl net-tools nettle && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
+  packer init . && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip
   
 RUN yum -y update

--- a/docker/ubi8/Dockerfile-dev
+++ b/docker/ubi8/Dockerfile-dev
@@ -39,7 +39,7 @@ COPY jaeger/opentelemetry-javaagent.jar /opt/jaeger/opentelemetry-javaagent.jar
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.9.1
+ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 
@@ -48,6 +48,7 @@ WORKDIR /packer
 RUN yum install -y java-17-openjdk-devel wget unzip curl tar git  openssl  net-tools nettle  && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
+  packer init . && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip
  
 

--- a/docker/ubi8/Dockerfile-fips
+++ b/docker/ubi8/Dockerfile-fips
@@ -37,7 +37,7 @@ COPY halconfig/packer              /opt/rosco/config/packer
 
 ENV KUSTOMIZE_VERSION=5.0.3
 
-ENV PACKER_VERSION=1.9.1
+ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 
@@ -46,6 +46,7 @@ WORKDIR /packer
 RUN yum install -y java-17-openjdk-devel wget unzip curl tar git  openssl  net-tools nettle  && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
+  packer init . && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip
  
 


### PR DESCRIPTION
**Jira** : https://devopsmx.atlassian.net/browse/OP-21845
**Summary** : Upgraded packer version : [ref](https://github.com/hashicorp/packer/releases)
**Testing** : 
1. compile successful, no new TCs failed bcoz of this
2. deployed aman1603/rosco:1march1 on qacve & bake successful : [ref](https://deck-qa.cve.opsmx.net/#/applications/feb19/executions/01HQWAPKX0JVSH7B3N8X845M1Q?pipeline=ec2-deploy-qa&stage=1&step=0&details=bakeConfig)
3. Created trivy-scan locally, this CVE not found

**Pre-merge** : NA
**Post-merge** : QA regression testing