### PR TITLE
OP-21899 Packer fixed - Replaced init with plugins install

### DIFF
--- a/docker/ubi8/Dockerfile
+++ b/docker/ubi8/Dockerfile
@@ -13,7 +13,6 @@ WORKDIR /packer
 RUN yum install -y java-17-openjdk-devel wget unzip curl tar git  openssl curl net-tools nettle && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
-  packer init . && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip
   
 RUN yum -y update
@@ -39,4 +38,15 @@ ENV PATH "kustomize:$PATH"
 RUN useradd spinnaker
 RUN mkdir -p /opt/rosco/plugins
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
+RUN for plugin in $PACKER_PLUGINS ; do \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]

--- a/docker/ubi8/Dockerfile-dev
+++ b/docker/ubi8/Dockerfile-dev
@@ -43,15 +43,10 @@ ENV PACKER_VERSION=1.10.1
 
 WORKDIR /packer
 
-
-
 RUN yum install -y java-17-openjdk-devel wget unzip curl tar git  openssl  net-tools nettle  && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
-  packer init . && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip
- 
-
 
 ENV PATH "/packer:$PATH"
 
@@ -94,4 +89,15 @@ RUN mv Armory.armory-observability-plugin-${CUSTOMPLUGIN_RELEASEVERSION}-SNAPSHO
 RUN chmod -R 777 /opt/rosco/plugins/
 RUN chown -R spinnaker:spinnaker /opt/
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
+RUN for plugin in $PACKER_PLUGINS ; do \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]

--- a/docker/ubi8/Dockerfile-fips
+++ b/docker/ubi8/Dockerfile-fips
@@ -38,18 +38,12 @@ COPY halconfig/packer              /opt/rosco/config/packer
 ENV KUSTOMIZE_VERSION=5.0.3
 
 ENV PACKER_VERSION=1.10.1
-
 WORKDIR /packer
-
-
 
 RUN yum install -y java-17-openjdk-devel wget unzip curl tar git  openssl  net-tools nettle  && \
   wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
   unzip packer_${PACKER_VERSION}_linux_amd64.zip && \
-  packer init . && \
   rm packer_${PACKER_VERSION}_linux_amd64.zip
- 
-
 
 ENV PATH "/packer:$PATH"
 
@@ -92,4 +86,15 @@ RUN chmod -R 777 /opt/rosco/plugins/
 RUN chown -R spinnaker:spinnaker /opt/
 RUN yum -y remove tar vim vi
 USER spinnaker
+
+# Install packer plugins (must be run as spinnaker user). To provide a github token (optional), run docker build with something like "--secret id=github_token,env=PACKER_GITHUB_API_TOKEN"
+ARG PACKER_PLUGINS="amazon azure googlecompute"
+RUN for plugin in $PACKER_PLUGINS ; do \
+  if [ -f /run/secrets/github_token ]; then \
+    PACKER_GITHUB_API_TOKEN=$(cat /run/secrets/github_token) packer plugins install "github.com/hashicorp/$plugin"; \
+  else \
+    packer plugins install "github.com/hashicorp/$plugin"; \
+  fi; \
+done
+
 CMD ["/opt/rosco/bin/rosco"]


### PR DESCRIPTION
**Ref** : https://github.com/spinnaker/rosco/commit/c0e6d3b5ff7926ae51dc081628abb99c1c7ea7c5
**Jira** : https://devopsmx.atlassian.net/browse/OP-21899

**Summary** :
Now packer init is not able to install required plugins, so replaced with packer plugins install <pluginName>
PACKER_PLUGINS consists all plugins that we wish to install.

**Testing** :
deployed aman1603/rosco:13march3 on ns=qacve, bake working (instance=https://deck-qa.cve.opsmx.net/, appName=feb19, pipeline=ec2-deploy-qa)